### PR TITLE
Footerのレイアウト幅調整

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -69,6 +69,7 @@ const currentYear = new Date().getFullYear();
     flex-wrap: wrap;
     margin-inline: auto;
     max-inline-size: var(--site-max-width);
+    padding: 0 1.5rem;
   }
 
   .footer-section h3 {


### PR DESCRIPTION
# 概要 
- LPのfooterがSP程度のサイズで余白が消える問題の修正

# 画像
| Before | After |
| ---- | ---- |
| <img width="798" height="436" alt="CleanShot 2026-01-14 at 00 04 12@2x" src="https://github.com/user-attachments/assets/74c62e19-b9ce-4fbf-bdcd-f5abfc573881" /> | <img width="806" height="386" alt="CleanShot 2026-01-14 at 00 02 33@2x" src="https://github.com/user-attachments/assets/43a1b398-4a7c-4bae-99e8-de700f2bacec" /> |