### PR TITLE
ヒーローイメージのCLSを修正

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -29,8 +29,9 @@ const {
         src={logoImage.src}
         alt="Frontend Conference Fukuoka"
         class="hero__logo"
-        width="300"
-        height="300"
+        width="320"
+        height="484"
+        fetchpriority="high"
       />
 
       <h1 class="hero__title">Frontend Conference Fukuoka {year}</h1>
@@ -183,6 +184,7 @@ const {
       width: 50cqi;
       max-width: 300px;
       height: auto;
+      aspect-ratio: 320 / 484;
       animation: fade-in-up 1.2s cubic-bezier(0.16, 1, 0.3, 1) 0.4s backwards;
     }
 


### PR DESCRIPTION
フロントエンドカンファレンス福岡を引き継いていただきありがとうございます。
いくつか気になる点があったので、勝手ながらPR作成させていただきます！（これが1つ目）

## 修正内容

トップページのヒーローイメージのwidth, heightの値を実際の画像サイズに合致するものに修正しました。

## 背景・目的

トップページのロゴ部分のwidth, height指定が画像のアスペクト比として一致しておらず、CSS上も`height: auto` が指定されているため、画像読み込み前後でCLSが発生していました（以下動画は現行本番環境）。

https://github.com/user-attachments/assets/99bd6b90-137c-4c43-8c35-c5a907461220

また画像が優先的に読み込まれるように `fetchpriority` を追加しました（これは実際のところあまり意味ないかも）。

## 対応しなかったこと

CLSが目立つ原因としてヒーローイメージのSVGにしては結構重いということもあると思うのですが、SVG生成の元となったデータがなく修正をしにくいため今回スコープ外としました。