### PR TITLE
スポンサー募集のテキストを削除

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -29,9 +29,7 @@ export const ui = {
     "timetable.title": "タイムテーブル",
     "sponsors.title": "スポンサー",
     "sponsors.description": "ご協賛いただいている企業・団体の皆さま",
-    "sponsors.recruiting":
-      "現在スポンサーを募集中しています。詳細は募集要項をご覧ください：",
-    "sponsors.recruitingLinkText": "スポンサー募集要項",
+    "sponsors.recruiting": "スポンサー募集は終了しました。",
     "access.title": "アクセス",
     "access.venue": "会場",
     "access.detailsLater": "詳細は後日発表します",
@@ -96,9 +94,7 @@ export const ui = {
     "timetable.title": "Timetable",
     "sponsors.title": "Sponsors",
     "sponsors.description": "Our sponsors and partners",
-    "sponsors.recruiting":
-      "We are currently looking for sponsors. Please see the recruitment guidelines for details: ",
-    "sponsors.recruitingLinkText": "Sponsor Recruitment Guidelines",
+    "sponsors.recruiting": "Sponsor recruitment has closed.",
     "access.title": "Access",
     "access.venue": "Venue",
     "access.detailsLater": "Details will be announced later",

--- a/src/pages/2026/index.astro
+++ b/src/pages/2026/index.astro
@@ -292,11 +292,7 @@ const eventDescription =
         )
       }
       <p class="sponsor-info">
-        {t("sponsors.recruiting")}<a
-          href="https://docs.google.com/presentation/d/1i7vePglNPltZtGSOBZVaNk1XvYWu9N6FWc6qfmDYWgY/edit?usp=sharing"
-          target="_blank"
-          rel="noopener noreferrer">{t("sponsors.recruitingLinkText")}</a
-        >
+        {t("sponsors.recruiting")}
       </p>
     </section>
   </div>


### PR DESCRIPTION
## 修正内容
現行サイトには `現在スポンサーを募集中しています。詳細は募集要項をご覧ください：スポンサー募集要項` を
`スポンサー募集は終了しました。` にしました。

## 背景・目的

サイト上の「今後のスケジュール」を見る限りだとスポンサー募集は終了しているはずなので、内容が矛盾しているように見えます。
※もし仮に募集継続しているのであれば、それとわかるように書き直す必要があると思います。