### PR TITLE
fix: Safari向けに `scroll-state` のフォールバック追加

### DIFF
--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -108,9 +108,7 @@ const t = useTranslations(lang);
   @layer components {
     .stuck-top {
       grid-area: nav;
-      container-type: scroll-state; /* when scroll-state available */
-      container-type: inline-size; /* when only inline-size available */
-      container-type: inline-size scroll-state; /* when both available */
+      container-type: inline-size;
       position: sticky;
       z-index: 1000;
       top: 20px;
@@ -139,6 +137,21 @@ const t = useTranslations(lang);
       margin-inline: 0;
 
       @container scroll-state(stuck: top) {
+        background: color-mix(
+          in oklch,
+          var(--color-base-darkest),
+          transparent 10%
+        );
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+        border-radius: 100px;
+        -webkit-backdrop-filter: blur(2px);
+        backdrop-filter: blur(2px);
+        border: 1px solid #ffffff14;
+      }
+    }
+
+    @supports not (container-type: scroll-state) {
+      .nav {
         background: color-mix(
           in oklch,
           var(--color-base-darkest),

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -108,7 +108,8 @@ const t = useTranslations(lang);
   @layer components {
     .stuck-top {
       grid-area: nav;
-      container-type: inline-size;
+      container-type: inline-size; /* when only inline-size available */
+      container-type: inline-size scroll-state; /* when scroll-state available */
       position: sticky;
       z-index: 1000;
       top: 20px;


### PR DESCRIPTION
## 概要
Safari で `scroll-state` コンテナクエリが未対応のため、ナビゲーションの sticky 状態スタイルが適用されない問題に対応しました。

## 変更内容
- `src/components/layout/Navigation.astro`
  - `container-type` を `inline-size` に整理
  - 既存の `@container scroll-state(stuck: top)` は維持
  - `@supports not (container-type: scroll-state)` を追加し、未対応ブラウザ（Safari）向けに `.nav` へ同等スタイルを適用

|  Before  |  After  |
| ---- | ---- |
|  ![](https://github.com/user-attachments/assets/b37409f1-eeb6-4019-bcb8-3e443825191d) | ![](https://github.com/user-attachments/assets/a1bab539-6758-430a-ace3-799437f1ffff)  |

## 期待される効果
- `scroll-state` 対応ブラウザ: 従来どおり sticky 時のみ装飾
- Safari など未対応ブラウザ: フォールバックにより見た目崩れを回避

## 動作確認
- `astro check` 通過
- `eslint` 通過
- `prettier --check` 通過（対象コミット）