### PR TITLE
refactor: スポンサーカードの余白を拡大

### DIFF
--- a/src/components/SponsorsEmbed.astro
+++ b/src/components/SponsorsEmbed.astro
@@ -169,7 +169,7 @@ const individualSponsors = supportersData.individuals.map((s) => {
          don't stretch a logo to the full content width. */
       max-inline-size: 280px;
       aspect-ratio: 3 / 2;
-      padding: clamp(0.875rem, 2.2vw, 1.25rem);
+      padding: 2rem;
       display: flex;
       place-items: center;
       justify-content: center;


### PR DESCRIPTION
## 概要
スポンサー一覧カードの内側余白を調整し、ロゴ周辺の見た目にゆとりを持たせました。

## 変更内容
- `src/components/SponsorsEmbed.astro` の `.sponsors__item` にある `padding` を拡大
- 旧: `clamp(0.875rem, 2.2vw, 1.25rem)`
- 新: `2rem`

## 期待される効果
- スポンサーロゴ周辺の窮屈さを軽減
- カード内の視認性と余白バランスを改善

## 影響範囲
- スポンサー表示セクションのカードレイアウトのみ

## 確認観点
- デスクトップ/モバイルで余白が過大になっていないこと
- ロゴがカード内で適切に収まること